### PR TITLE
Continent size in debug options

### DIFF
--- a/DebugUtils.cs
+++ b/DebugUtils.cs
@@ -171,10 +171,6 @@ public partial class DebugUtils
                         defaultValue: 0.5f, minValue: 0, maxValue: 1,
                         setter: SetHeightmapValue<float>(value => BetterContinents.Settings.SeaLevel = value),
                         getter: () => BetterContinents.Settings.SeaLevel);
-                    group.AddValue("oc", "Ocean channels", "whether ocean channels are enabled",
-                        defaultValue: true,
-                        setter: SetHeightmapValue<bool>(value => BetterContinents.Settings.OceanChannelsEnabled = value),
-                        getter: () => BetterContinents.Settings.OceanChannelsEnabled);
                     group.AddValue("r", "Rivers", "whether rivers are enabled",
                         defaultValue: true,
                         setter: SetHeightmapValue<bool>(value => BetterContinents.Settings.RiversEnabled = value),

--- a/DebugUtils.cs
+++ b/DebugUtils.cs
@@ -163,11 +163,19 @@ public partial class DebugUtils
             bc.AddGroup("g", "Global", "global settings, get more info with 'bc g help'",
                 group =>
                 {
+                    group.AddValue("cs", "Continent size adjustment", "continent size adjustment",
+                        defaultValue: 0.5f, minValue: 0, maxValue: 1,
+                        setter: SetHeightmapValue<float>(value => BetterContinents.Settings.ContinentSize = value),
+                        getter: () => BetterContinents.Settings.ContinentSize);
                     group.AddValue("sl", "Sea level adjustment", "sea level adjustment",
                         defaultValue: 0.5f, minValue: 0, maxValue: 1,
                         setter: SetHeightmapValue<float>(value => BetterContinents.Settings.SeaLevel = value),
                         getter: () => BetterContinents.Settings.SeaLevel);
-                    group.AddValue("r", "Enable rivers", "whether rivers are enabled",
+                    group.AddValue("oc", "Ocean channels", "whether ocean channels are enabled",
+                        defaultValue: true,
+                        setter: SetHeightmapValue<bool>(value => BetterContinents.Settings.OceanChannelsEnabled = value),
+                        getter: () => BetterContinents.Settings.OceanChannelsEnabled);
+                    group.AddValue("r", "Rivers", "whether rivers are enabled",
                         defaultValue: true,
                         setter: SetHeightmapValue<bool>(value => BetterContinents.Settings.RiversEnabled = value),
                         getter: () => BetterContinents.Settings.RiversEnabled);


### PR DESCRIPTION
Added missing "continent size" command to debug options, which makes it also appear in the live edit panel.